### PR TITLE
fix : 화면 비율에 따라 CSS 깨지던 오류 수정

### DIFF
--- a/src/components/MainContentBox/MainContentBox.style.js
+++ b/src/components/MainContentBox/MainContentBox.style.js
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 
 export const MainContentBoxContainer = styled.div`
   margin: 0 146px;
+  margin-bottom : 40px;
 `
 
 export const MenuList = styled.ul`

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -6,7 +6,7 @@ const GlobalStyle = createGlobalStyle`
     flex-direction: column;
     align-items: center;
     justify-content: flex-start;
-    height: 100vh;
+    height: 100%;
     width: 100%;
   }
   body {


### PR DESCRIPTION
## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>

![수정 전](https://github.com/user-attachments/assets/2a2620db-e945-4b69-ac07-08022dd5f10a)
- 수정 전 모습
- 배경 이미지가 끝까지 적용되지 않음
- main ContentBox 밑단에 margin이 없음

![수정 후](https://github.com/user-attachments/assets/6b064af8-aa44-4734-a25e-90eb58e64f24)
- global style에서 root의 height를 100vh가 아닌 100%로 조정 (비율에 따라 배경 이미지가 잘리던 현상 해결)
- main ContentBox의 bottom에 margin 추가

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #{이슈넘버}
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
